### PR TITLE
Remove deprecated and unsafe TLS v1 and v1.1 protocols and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ they have a free DNS service that provide wildcard DNS for any IP
 address, including private IPs:
 
     $ dig 10-0-0-1.my.local-ip.co +short
+
     10.0.0.1
 
 So having a public certificate and a public DNS that resolves to your
@@ -100,7 +101,7 @@ Also a convenient environment file can be used to store the new values as sugges
 **my.env file:**
 
     HTTP=8080
-    HTTPS=8444
+    HTTPS=444
 
 Run with: `APP_URL=https://192.168.1.3:5988 docker-compose --env-file=my.env up`
 

--- a/default.conf.template
+++ b/default.conf.template
@@ -12,7 +12,7 @@ server {
   ssl_certificate           /etc/nginx/server.chained.pem;
   ssl_certificate_key       /etc/nginx/server.key;
 
-  ssl_protocols TLSv1.2;
+  ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 
   sendfile                  on;
   tcp_nopush                on;


### PR DESCRIPTION
XWalk well support TLS v1.2 so there is no reason to leave older versions of the protocol, also making the Nginx config simpler.