### PR TITLE
YML:  explicit name, yml version and image name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,15 @@
-app:
-  build: .
-  ports:
-    - "${HTTP}:80"
-    - "${HTTPS}:443"
-  volumes:
-    - ./default.conf.template:/etc/nginx/templates/default.conf.template
-    - ./entrypoint.sh:/entrypoint.sh
-  environment:
-    APP_URL: $APP_URL
+version: "3.7"
+
+services:
+  nginx-local-ip:
+    container_name: nginx-local-ip 
+    image: medicmobile/nginx-local-ip
+    build: .
+    ports:
+      - "${HTTP}:80"
+      - "${HTTPS}:443"
+    volumes:
+      - ./default.conf.template:/etc/nginx/templates/default.conf.template
+      - ./entrypoint.sh:/entrypoint.sh
+    environment:
+      APP_URL: $APP_URL


### PR DESCRIPTION
This avoids docker calling this container `nginx-local-ip_app_1` in `docker ps` as well as brings nomenclature parity with [`cht-core`'s `docker-compose.yml`](https://github.com/medic/cht-core/blob/master/docker-compose.yml).

note:
* 3.7 is yml version, not nginx-local-ip version
* `medicmobile` is deprecated, so should be `medic`, but we haven't moved anything yet, so sticking with what have already
* don't forget to test with `--build`!