### PR TITLE
allow couchdb-prometheus-exporter to run against CHT Docker instances

### DIFF
--- a/base-path.json
+++ b/base-path.json
@@ -1,1 +1,0 @@
-{   "couchdb": "Welcome",   "version": "2.3.1",   "git_sha": "c298091a4",   "uuid": "3ed6967923ff8b83f5e7f216b4653f94",   "features": [     "pluggable-storage-engines",     "scheduler"   ],   "vendor": {     "name": "The Apache Software Foundation"   } } 

--- a/base-path.json
+++ b/base-path.json
@@ -1,0 +1,13 @@
+{
+  "couchdb": "Welcome",
+  "version": "2.3.1",
+  "git_sha": "c298091a4",
+  "uuid": "3ed6967923ff8b83f5e7f216b4653f94",
+  "features": [
+    "pluggable-storage-engines",
+    "scheduler"
+  ],
+  "vendor": {
+    "name": "The Apache Software Foundation"
+  }
+}

--- a/base-path.json
+++ b/base-path.json
@@ -1,13 +1,1 @@
-{
-  "couchdb": "Welcome",
-  "version": "2.3.1",
-  "git_sha": "c298091a4",
-  "uuid": "3ed6967923ff8b83f5e7f216b4653f94",
-  "features": [
-    "pluggable-storage-engines",
-    "scheduler"
-  ],
-  "vendor": {
-    "name": "The Apache Software Foundation"
-  }
-}
+{   "couchdb": "Welcome",   "version": "2.3.1",   "git_sha": "c298091a4",   "uuid": "3ed6967923ff8b83f5e7f216b4653f94",   "features": [     "pluggable-storage-engines",     "scheduler"   ],   "vendor": {     "name": "The Apache Software Foundation"   } } 

--- a/default.conf.template
+++ b/default.conf.template
@@ -25,6 +25,11 @@ server {
   proxy_max_temp_file_size  0;
   client_max_body_size      32M; # Match maximum body parser limits from cht-core api
 
+  location = / {
+    add_header  Content-Type    application/json;
+    return 200 '{   "couchdb": "Welcome",   "version": "2.3.1",   "git_sha": "c298091a4",   "uuid": "3ed6967923ff8b83f5e7f216b4653f94",   "features": [     "pluggable-storage-engines",     "scheduler"   ],   "vendor": {     "name": "The Apache Software Foundation"   } } ';
+  }
+  
   location / {
 
     proxy_set_header        Host $host;

--- a/default.conf.template
+++ b/default.conf.template
@@ -32,7 +32,6 @@ server {
   
   location / {
 
-    proxy_set_header        Host $host;
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Proto $scheme;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "${HTTPS}:443"
     volumes:
       - ./default.conf.template:/etc/nginx/templates/default.conf.template
-      - ./base-path.json:/usr/share/nginx/base-path.json
       - ./entrypoint.sh:/entrypoint.sh
     environment:
       APP_URL: $APP_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "${HTTPS}:443"
     volumes:
       - ./default.conf.template:/etc/nginx/templates/default.conf.template
+      - ./base-path.json:/usr/share/nginx/base-path.json
       - ./entrypoint.sh:/entrypoint.sh
     environment:
       APP_URL: $APP_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,4 @@ networks:
     ipam:
       config:
         - subnet: 172.16.0.0/16
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,3 @@ networks:
     ipam:
       config:
         - subnet: 172.16.0.0/16
-


### PR DESCRIPTION
DO NOT MERGE AS IS!

Some tools, like [CouchDB Prometheus Exporter](https://github.com/gesellix/couchdb-prometheus-exporter/), would like to talk directly CouchDB.

[The CHT](https://github.com/medic/cht-core/) doesn't directly expose CouchDB so you can't make a call to `https://YOUR-CHT-INSTANCE/` and get a JSON of couch instance.  Instead you either have to talk directly to the container where couch is running (when running a separate one like in [a dev scenario](https://docs.communityhealthtoolkit.org/contribute/code/core/dev-environment/)) or edit your compose file to directly expose the CouchDB container.  

This PR is a proof of concept on how we might trick an external service into thinking it's talking directly to a couch instance. We do this by using this repos reverse proxy to serving up a static JSON file on `/` so an inquiring service would see a "valid" couch instance on `/`, but then any given database (ie `/medic/`) would be there too by passing the traffic through to the reverse proxy.  

POC is currently only 4 lines :sunglasses: 