### PR TITLE
feat: make Docker image self-contained

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,0 +1,39 @@
+name: Publish nginx-local-ip image
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  DOCKER_HUB_USER: dockermedic
+  DOCKER_NAMESPACE: medicmobile
+  DOCKER_REPOSITORY: nginx-local-ip
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASS }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_NAMESPACE }}/${{ env.DOCKER_REPOSITORY }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM nginx:1.28-alpine
 
+RUN apk add --no-cache openssl coreutils
+
 COPY default.conf.template /etc/nginx/templates/default.conf.template
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
-FROM nginx:1.19
+FROM nginx:1.28-alpine
 
-EXPOSE 80 443
+COPY default.conf.template /etc/nginx/templates/default.conf.template
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV CERT_PEM_SRC=https://local-ip.medicmobile.org/cert
+ENV CERT_CHAIN_SRC=https://local-ip.medicmobile.org/chain
+ENV CERT_KEY_SRC=https://local-ip.medicmobile.org/key
+ENV DOMAIN=local-ip.medicmobile.org
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you have a webapp running locally on port `5988`, and your local IP is `192.1
 To run nginx-local-ip in front of your webapp, simply launch the Docker container with the following command:
 
 ```shell
-docker run --rm \
+docker run --rm --pull always\
     -e APP_URL=http://192.168.0.3:5988 \
     -p 443:443 \
     medicmobile/nginx-local-ip

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ docker run --rm \
     medicmobile/nginx-local-ip
 ```
 
-Now you should be able to access your app at `https://192-168-0-3.local-ip.medicmobile.org`! When you are done, simple cancel the command or close the terminal and the nginx-local-ip container will be automatically removed.
+_(After the container starts, scroll up in the terminal output to see the "nginx-local-ip URL" for your app!)_
+
+Now you should be able to access your app at `https://192-168-0-3.local-ip.medicmobile.org`! When you are done, simply cancel the command or close the terminal and the nginx-local-ip container will be automatically removed.
 
 (See the included [Compose file](./compose.yaml) for examples of more advanced configuration options.)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   nginx-local-ip:
     container_name: nginx-local-ip 
@@ -10,7 +8,6 @@ services:
       - "${HTTPS}:443"
     volumes:
       - ./default.conf.template:/etc/nginx/templates/default.conf.template
-      - ./entrypoint.sh:/entrypoint.sh
     environment:
       APP_URL: $APP_URL
       HTTP: $HTTP
@@ -24,4 +21,5 @@ networks:
   default:
     ipam:
       config:
+        # Useful for ensuring the assigned network address is within the range configured for your firewall rules
         - subnet: 172.16.0.0/16

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$APP_URL" != "" ]; then
   echo -e "$0: \033[1;1m\$APP_URL\033[0m set to $APP_URL"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,11 +38,10 @@ else
   install_certs
 fi
 
-CERT_EXP_DATE=$(openssl x509 -enddate -noout -in $CERT_PEM | grep -oP 'notAfter=\K.+')
-CERT_EXP_DATE_ISO=$(date -d "$CERT_EXP_DATE" '+%Y-%m-%d')
-
-TODAY_ISO=$(date '+%Y-%m-%d')
-if [[ "$CERT_EXP_DATE_ISO" < "$TODAY_ISO" ]]; then
+CERT_EXP_DATE=$(openssl x509 -enddate -noout -in $CERT_PEM | sed -n 's/^.*notAfter=//p')
+CERT_EXP_DATE_EPOCH=$(date -d "$CERT_EXP_DATE" +%s)
+TODAY_EPOCH=$(date +%s)
+if [ "$CERT_EXP_DATE_EPOCH" -lt "$TODAY_EPOCH" ]; then
   if [ "$DOWNLOAD" == "false" ]; then
     echo "$0: SSL certificate expired! Installing new certificate files ..."
     install_certs


### PR DESCRIPTION
The goal of this PR is to further operationalize this service with the goal of making it easier to consume (without limiting its flexibility).

I have updated the Dockerfile to include the necessary configuration files and default envar values in the Docker image, itself, (instead of needing to inject them at runtime).  This allows the image to be used without needing to clone the nginx-local-ip repo.

If this approach is acceptable, I have also included GitHub action configuration which should allow for automatically publishing a new version of the docker image whenever new changes are pushed to the `main` branch of this repo.  This config is based on what we are using [in cht-conf](https://github.com/medic/cht-conf/blob/main/.github/workflows/publish_docker_image.yml) to publish the cht-app-ide image.  Some additional manual configuration will be needed to get the image building to work (which I can do if this PR is approved).  Context:
- https://github.com/medic/cht-conf/pull/546
- https://github.com/medic/medic-infrastructure/issues/570
- https://github.com/medic/cht-conf/pull/558
- https://github.com/medic/cht-conf/pull/559

