### PR TITLE
fix: update GitHub workflow to publish `latest` tag

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: latest
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Okay, we got really close!  :sweat_smile: The image published, but with the `main` tag (instead of `latest`).  I think this is just part of the default settings for `docker/metadata-action` when running on a branch build (and not a tag).  

I don't think we really want/need branch tags for this repo, so I have updated the workflow config to always just push a new version of `latest` whenever a commit is added to `main`.  This should be the most simple/straightforward approach. :+1: 

https://hub.docker.com/repository/docker/medicmobile/nginx-local-ip/tags