### PR TITLE
fix: use flavor config to properly tag latest

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -29,11 +29,12 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.DOCKER_NAMESPACE }}/${{ env.DOCKER_REPOSITORY }}
+          flavor: latest=true
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: latest
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Sigh... :disappointed:  3rd time is the charm!  :crossed_fingers: 

It turns out my simplistic assumption of the `tags` config was wrong.  If you compare the logs for the [working run](https://github.com/medic/nginx-local-ip/actions/runs/15325632644/job/43119323077) that published the `main` tag vs the current [broken run](https://github.com/medic/nginx-local-ip/actions/runs/15333711431/job/43146843253), you can see that the working run is using `--tag medicmobile/nginx-local-ip:main` while the broken run has `--tag latest`.  So basically the `tags` config is setting the _exact and entire_ image tag that will be used (including the repo/image-name).  

Instead of doubling down on my hard-coding approach, I actually dug into [the documentation](https://github.com/docker/metadata-action#flavor-input) and found that I should actually have been setting the `flavor` config for the `docker/metadata-action` (so that my desired `latest` tag can get combined with the proper repo/image-name.  