### PR TITLE
chore(#32): bump nginx to 1.31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.28-alpine
+FROM nginx:1.31.0-alpine
 
 RUN apk add --no-cache openssl coreutils
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ A local image is created the first time the command executed, and there is no ne
 
 If you do need to rebuild the container, append `--build` on to your compose call: ` docker compose up --build`.
 
+When doing a release, be sure to bump the version in the `compose.yaml` file on the `image:` line. This will forcibly rebuild the image for anyone using it downstream without them needing to know about the infrequently used `--build` flag:
+
+```dockerfile
+services:
+  nginx-local-ip:
+    container_name: nginx-local-ip 
+    image: medicmobile/nginx-local-ip:1.0.0 # bump this version every release, forces image rebuild
+    build: .
+```
+
 Requirements
 ------------
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   nginx-local-ip:
     container_name: nginx-local-ip 
-    image: medicmobile/nginx-local-ip
+    image: medicmobile/nginx-local-ip:1.0.0 # bump this version every release, forces image rebuild
     build: .
     ports:
       - "${HTTP}:80"


### PR DESCRIPTION

# Description

* Bumps `nginx` in Dockerfile from `1.25.1` to latest `1.31.0`
* adds a version number to compose file image name. this forces image to rebuild anytime the version is incremented 

I tested:
* compose file with and without `1.0.0` version to verify it does NOT rebuild when no version is there, but the Dockerfile is changed - hence adding the version
* tested the proxy works:
   1. start simple web server with the ol' one liner: `python3 -m http.server`
   2. start proxy with my IP and port pointing to simple python http server: `APP_URL=http://192.168.68.26:8000 docker compose up`
   3. `curl` works as expected and shows latest version of `nginx`
	```
	curl  -v  https://192-168-68-26.local-ip.medicmobile.org  2>&1 | grep -E 'nginx/|200'    
	< HTTP/1.1 200 OK
	< Server: nginx/1.31.0
	```
* verified that old compose file would build a `latest` version, but new approach builds explicit `1.0.0` which has a different ID, showing it's an updated image just from calling `docker compose up`
	```
	docker image ls --format table|grep -E 'REPOS|medicmobile/nginx-local-ip'
	REPOSITORY                                                         TAG                                 IMAGE ID       CREATED         SIZE
	medicmobile/nginx-local-ip                                         1.0.0                               c72790cecf17   12 hours ago    64.8MB
	medicmobile/nginx-local-ip                                         latest                              0a9ec38ae598   11 months ago   50.6MB
	```

closes #32


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

